### PR TITLE
Add Change Diffing to Optimize re-rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@dittolive/ditto": "^4.7.1"
+        "@dittolive/ditto": "^4.9.2",
+        "microdiff": "^1.5.0"
       },
       "devDependencies": {
         "parcel": "^2.12.0"
@@ -129,13 +130,11 @@
       "integrity": "sha512-oYWcD7CpERZy/TXMTM9Tgh1HD/POHlbY9WpzmAk+5H8DohcxG415Qws8yLGlim3EaKBT2v3lJv01x4G0BosnaQ=="
     },
     "node_modules/@dittolive/ditto": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@dittolive/ditto/-/ditto-4.7.1.tgz",
-      "integrity": "sha512-ld464N2IhemDUXMwgRFQN66u75fplzC7U/sOa94/0XNixsMLRSOg4Ax1Y6tz/hU06f8eiMOh6Fz/AwwDyrmObw==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@dittolive/ditto/-/ditto-4.9.2.tgz",
+      "integrity": "sha512-hFFmTmHiE2pMrFPXCQnCCjztudyn0JkWVVOt1Fvcxf0V+AWlLCXt43rlxCquX+Ii65ysRMtwsK8yQ5dx6t2efw==",
       "dependencies": {
-        "@ungap/weakrefs": "^0.2.0",
-        "cbor-redux": "^1.0.0",
-        "fastestsmallesttextencoderdecoder": "^1.0.22"
+        "cbor-redux": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -1587,11 +1586,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/@ungap/weakrefs": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/weakrefs/-/weakrefs-0.2.0.tgz",
-      "integrity": "sha512-6MGYS+dIJG9yzI2j54jwkZZ5sobysMyMVbvQPfDlxBdVNI0OGgbePMNooosUnoYb9YgaJaQ52L45+0T6huIuVA=="
-    },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz",
@@ -2085,11 +2079,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw=="
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2391,6 +2380,11 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "node_modules/microdiff": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/microdiff/-/microdiff-1.5.0.tgz",
+      "integrity": "sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q=="
     },
     "node_modules/micromatch": {
       "version": "4.0.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "parcel": "^2.12.0"
   },
   "dependencies": {
-    "@dittolive/ditto": "^4.7.1"
+    "@dittolive/ditto": "^4.9.2",
+    "microdiff": "^1.5.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -44,6 +44,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // We'll start by diffing the current from the previous to see if there are any changes
     const diffResult = diff(prevResultItems, newResultItems)
     diffResult.forEach(docDiff => {
+      console.log(JSON.stringify(docDiff));
       // Remove only items that have changed and we'll re-add them
       const list = document.getElementById('colorList');
       // path[0] is set to the document _id which we use as the unique element id
@@ -56,7 +57,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           break;
         case 'CHANGE':
           const pathStr = docDiff.path.slice(1).join('.');
-          console.log(`Changed Document: ['${docId}'] with path ['${pathStr}'] from '${docDiff.previous}' to '${docDiff.value}'.`);
+          console.log(`Changed Document: ['${docId}'] with path ['${pathStr}'] from '${docDiff.oldValue}' to '${docDiff.value}'.`);
           
           const itemToChange = document.getElementById(docId);
           itemToChange.style.color = docDiff.value;
@@ -71,7 +72,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           // list.removeChild(childToRemove)
           break;
         case 'REMOVE':
-          console.log(`Removed Document: '${docId}' which had value '${JSON.stringify(docDiff.previous)}'.`);
+          console.log(`Removed Document: '${docId}' which had value '${JSON.stringify(docDiff.oldValue)}'.`);
           // The delete button already cleans up the element but we'll add this check to make sure it's gone
           const childItemToRemove = document.getElementById(docId.toString());
           if (childItemToRemove) {

--- a/src/app.js
+++ b/src/app.js
@@ -13,8 +13,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   await init();
   ditto = new Ditto({
     type: "onlinePlayground",
-    appID: "0fab7e5b-3d91-422d-b3e8-4ac6125c3b1e", // Add your Ditto App ID
-    token: "525817b6-274f-43f2-b03e-4f1396030f0c", // Add your Ditto Playground Token
+    appID: "YOUR_APP_ID", // Add your Ditto App ID
+    token: "YOUR_PLAYGROUND_TOKEN", // Add your Ditto Playground Token
   });
 
   ditto.disableSyncWithV3();
@@ -60,7 +60,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           break;
         case 'CHANGE':
           const fieldName = docDiff.path[1];
-          if (fieldName === 'color') {
+          if (fieldChanged === 'color') {
             // Get the element changed and update values
             console.log(`Changed Document: ['${docId}'] with path ['${fieldName}'] from '${docDiff.oldValue}' to '${docDiff.value}'.`);
             const itemToChange = document.getElementById(docId);

--- a/src/app.js
+++ b/src/app.js
@@ -34,6 +34,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Register a Ditto store observer that will look for change to the `colors` collection in the local Ditto store
   // Any local or remote changes will trigger this event
   // When an event fires we'll re-render only the changed items using a differ strategy
+  // This works by storing the previous result then using the microdiff library to compare the previous to the new value
   let prevResultItems = {};
   ditto.store.registerObserver("SELECT * FROM colors WHERE isDeleted = false", (result) => {
     
@@ -52,36 +53,34 @@ document.addEventListener('DOMContentLoaded', async () => {
       console.log("DOCID:" + docId);
       switch (docDiff.type) {
         case 'CREATE':
+          // A document has been added that we've not seen before. Append the item to the bottom of our colors list.
+          // Note: This will happen for all documents on the first load
           console.log(`New Document: '${docId}' with value '${JSON.stringify(docDiff.value)}'.`);
           generateColorItemAndAddItToTheList(docDiff.value)
           break;
         case 'CHANGE':
-          const pathStr = docDiff.path.slice(1).join('.');
-          console.log(`Changed Document: ['${docId}'] with path ['${pathStr}'] from '${docDiff.oldValue}' to '${docDiff.value}'.`);
-          
-          const itemToChange = document.getElementById(docId);
-          itemToChange.style.color = docDiff.value;
-          itemToChange.textContent = docDiff.value;
-          // // Get the current item 
-          // const childToRemove = document.getElementById(docId);
-          // // Generate the new item
-          // const newListItem = generateColorItem(docDiff.value);
-          // // Insert the new item after
-          // childToRemove.insertBefore(newListItem, childToRemove.nextSibling)
-          // // Remove old item
-          // list.removeChild(childToRemove)
+          const fieldName = docDiff.path[1];
+          if (fieldName === 'color') {
+            // Get the element changed and update values
+            console.log(`Changed Document: ['${docId}'] with path ['${fieldName}'] from '${docDiff.oldValue}' to '${docDiff.value}'.`);
+            const itemToChange = document.getElementById(docId);
+            itemToChange.style.color = docDiff.value;
+            itemToChange.textContent = docDiff.value;
+          }
+          else {
+            console.log(`unexpected field path changed ${docDiff.path}`);
+          }
           break;
         case 'REMOVE':
+          // The delete button already has logic to clean up the element but we'll add a check to make sure it's gone
           console.log(`Removed Document: '${docId}' which had value '${JSON.stringify(docDiff.oldValue)}'.`);
-          // The delete button already cleans up the element but we'll add this check to make sure it's gone
           const childItemToRemove = document.getElementById(docId.toString());
           if (childItemToRemove) {
             list.removeChild(childItemToRemove);
-          } else {
-            console.log("item already deleted");
           }
           break
         default:
+          console.log(`Unknown diff type: ${docDiff.type}`)
           break;
     }})
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,5 @@
 import { Ditto, init } from "@dittolive/ditto";
+import diff from "microdiff";
 
 // The ditto instance needs to remain in scope of the application to ensure it doesn't get
 // cleaned up.
@@ -12,9 +13,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   await init();
   ditto = new Ditto({
     type: "onlinePlayground",
-    appID: "YOUR_APP_ID", // Add your Ditto App ID
-    token: "YOUR_PLAYGROUND_TOKEN", // Add your Ditto Playground Token
+    appID: "0fab7e5b-3d91-422d-b3e8-4ac6125c3b1e", // Add your Ditto App ID
+    token: "525817b6-274f-43f2-b03e-4f1396030f0c", // Add your Ditto Playground Token
   });
+
+  ditto.disableSyncWithV3();
 
   // A sync subscription fetch all the documents in the colors collections devices/cloud
   //
@@ -30,24 +33,58 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Register a Ditto store observer that will look for change to the `colors` collection in the local Ditto store
   // Any local or remote changes will trigger this event
-  // When an event fires we'll re-render the list of colors based on which ones are not deleted
-  ditto.store.registerObserver("SELECT * FROM colors", (result) => {
+  // When an event fires we'll re-render only the changed items using a differ strategy
+  let prevResultItems = {};
+  ditto.store.registerObserver("SELECT * FROM colors WHERE isDeleted = false", (result) => {
     
-    // Clear the list in the DOM and we'll reset them
-    const list = document.getElementById('colorList');
-    while (list.firstChild) {
-      list.removeChild(list.firstChild);
-    }
+    const newResultItems = result.items.reduce((acc, item, index) => {
+      acc[item.value._id.toString()] = item.value;
+      return acc;
+    }, {});
+    // We'll start by diffing the current from the previous to see if there are any changes
+    const diffResult = diff(prevResultItems, newResultItems)
+    diffResult.forEach(docDiff => {
+      // Remove only items that have changed and we'll re-add them
+      const list = document.getElementById('colorList');
+      // path[0] is set to the document _id which we use as the unique element id
+      const docId = docDiff.path[0];
+      console.log("DOCID:" + docId);
+      switch (docDiff.type) {
+        case 'CREATE':
+          console.log(`New Document: '${docId}' with value '${JSON.stringify(docDiff.value)}'.`);
+          generateColorItemAndAddItToTheList(docDiff.value)
+          break;
+        case 'CHANGE':
+          const pathStr = docDiff.path.slice(1).join('.');
+          console.log(`Changed Document: ['${docId}'] with path ['${pathStr}'] from '${docDiff.previous}' to '${docDiff.value}'.`);
+          
+          const itemToChange = document.getElementById(docId);
+          itemToChange.style.color = docDiff.value;
+          itemToChange.textContent = docDiff.value;
+          // // Get the current item 
+          // const childToRemove = document.getElementById(docId);
+          // // Generate the new item
+          // const newListItem = generateColorItem(docDiff.value);
+          // // Insert the new item after
+          // childToRemove.insertBefore(newListItem, childToRemove.nextSibling)
+          // // Remove old item
+          // list.removeChild(childToRemove)
+          break;
+        case 'REMOVE':
+          console.log(`Removed Document: '${docId}' which had value '${JSON.stringify(docDiff.previous)}'.`);
+          // The delete button already cleans up the element but we'll add this check to make sure it's gone
+          const childItemToRemove = document.getElementById(docId.toString());
+          if (childItemToRemove) {
+            list.removeChild(childItemToRemove);
+          } else {
+            console.log("item already deleted");
+          }
+          break
+        default:
+          break;
+    }})
 
-    // For each item in the result set only show the ones not deleted
-    result.items.forEach(item => {
-      const doc = item.value;
-      if (!doc.isDeleted) 
-        addColorToList(item.value)
-    });
-
-    // Log the current document count after re-rendering
-    console.log(`Colors Collection Changed. Current document count: ${result.items.length}`);
+    prevResultItems = newResultItems;
   });
 
   // Get the generate color button and add an event handler for a click action
@@ -68,31 +105,53 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   // Render the color value with a delete button in the list
-  function addColorToList(colorDoc) {
-    const list = document.getElementById('colorList');
-      const listItem = document.createElement('li');
-      const colorText = document.createElement('span');
-      colorText.style.color = colorDoc.color
-      colorText.textContent = colorDoc.color;
-      colorText.style.marginRight = '10px';
-      
-      // create a delete button for the color list item
-      const deleteButton = document.createElement('button');
-      deleteButton.textContent = 'Delete';
-      deleteButton.addEventListener('click', () => {
-        // Set the deleted property to true for the id selected
-        ditto.store.execute(`
-          UPDATE colors
-          SET isDeleted = true
-          WHERE _id = :id`, { id: colorDoc._id })  
-        list.removeChild(listItem);
-      });
-
-      listItem.appendChild(colorText);
-      listItem.appendChild(deleteButton);
+  function generateColorItemAndAddItToTheList(colorDoc) {
+      // Remove only items that have changed and we'll re-add them
+      const list = document.getElementById('colorList');
+      const listItem = generateColorItem(colorDoc)
       list.appendChild(listItem);
   }
 });
+
+// Creates a new Color Item
+function generateColorItem(colorDoc) {
+  const list = document.getElementById('colorList');
+  const listItem = document.createElement('li');
+  const colorText = document.createElement('span');
+  colorText.style.color = colorDoc.color;
+  colorText.textContent = colorDoc.color;
+  colorText.style.marginRight = '10px';
+  colorText.setAttribute('id', colorDoc._id);
+  
+  // create a delete button for the color list item
+  const deleteButton = document.createElement('button');
+  deleteButton.textContent = 'Delete';
+  deleteButton.addEventListener('click', () => {
+    // Set the deleted property to true for the id selected
+    ditto.store.execute(`
+      UPDATE colors
+      SET isDeleted = true
+      WHERE _id = :id`, { id: colorDoc._id })  
+    list.removeChild(listItem);
+  });
+
+  // create a delete button for the color list item
+  const changeColorButton = document.createElement('button');
+  changeColorButton.textContent = 'Change Color';
+  changeColorButton.addEventListener('click', () => {
+    // Set the deleted property to true for the id selected
+    const newColor = generateRandomColor();
+    ditto.store.execute(`
+      UPDATE colors
+      SET color = '${newColor}'
+      WHERE _id = :id`, { id: colorDoc._id });
+  });
+
+  listItem.appendChild(colorText);
+  listItem.appendChild(changeColorButton);
+  listItem.appendChild(deleteButton);
+  return listItem;
+}
 
 // Generates a random hex color
 function generateRandomColor() {


### PR DESCRIPTION
This change introduces the the `microdiff` library to optimize re-rendering when the Ditto database changes. 

This works by storing the previous result and using the differ to determine what's changed between the previous and new result and selectively modifying only the items that have changed from the previous result.

Previously the code would just delete all the list items then re-rendering them all. Changing to an partial render approach required a bit of re-factoring on the core code base that you see below.

## Diffing Package Options
There are options when choosing a diffing package. I choose microdiff for this example because it's small and simple to parse. `deep-diff` and `deep-object-diff` are more powerful libraries that offer more but are larger in size.
 
- [microdiff](https://www.npmjs.com/package/microdiff)
- [deep-diff](https://www.npmjs.com/package/deep-diff)
- [deep-object-diff](https://www.npmjs.com/package/deep-object-diff)